### PR TITLE
WIP: Fix self functions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,8 @@ proc-macro = true
 
 [dependencies]
 failure = "0.1.5"
-syn = { version = "0.15", features = ["full", "extra-traits"] }
-proc-macro2 = { version = "0.4.24", features = ["nightly"] }
-quote = "0.6"
+syn = { version = "1.0.5", features = ["full"] }
+proc-macro2 = { version = "1.0.5" }
+quote = "1.0.2"
 
 [dev-dependencies]

--- a/examples/counter.rs
+++ b/examples/counter.rs
@@ -1,0 +1,44 @@
+use context_attribute::context;
+use failure::ensure;
+
+struct Counter(usize);
+
+impl Counter {
+    /// Counts down until the target number
+    #[context]
+    fn count(&mut self, target: usize) -> Result<(), failure::Error> {
+        ensure!(self.0 >= target, "Target is greater than current count");
+
+        while self.0 > target {
+            println!("{}", self.0);
+            self.0 -= 1;
+        }
+
+        Ok(())
+    }
+
+    /// Prints the numbers down to a target number without changing the current count
+    #[context]
+    fn print(&self, target: usize) -> Result<(), failure::Error> {
+        ensure!(self.0 >= target, "Target is greater than current count");
+
+        while self.0 > target {
+            println!("{}", self.0);
+        }
+
+        Ok(())
+    }
+}
+
+fn main() -> Result<(), failure::Error> {
+    ensure!(std::env::args().len() == 3, "usage: counter <num> <target>");
+    let input = std::env::args().skip(1).next().unwrap().parse()?;
+    let target = std::env::args().skip(2).next().unwrap().parse()?;
+
+    let mut counter = Counter(input);
+
+    counter.print(target)?;
+    counter.count(target)?;
+
+    Ok(())
+}

--- a/examples/counter.rs
+++ b/examples/counter.rs
@@ -1,5 +1,5 @@
 use context_attribute::context;
-use failure::ensure;
+use failure::{ensure, ResultExt};
 
 struct Counter(usize);
 

--- a/examples/read_string.rs
+++ b/examples/read_string.rs
@@ -2,11 +2,10 @@ use context_attribute::context;
 use failure::{Error, ResultExt};
 
 use std::fs;
-use std::net::SocketAddr;
 
 /// Read address.txt from disk
 fn read_file_1() -> Result<String, Error> {
-    let res = std::fs::read_to_string("address.txt")
+    let res = fs::read_to_string("address.txt")
         .context("error reading address.txt from disk")?
         .trim()
         .to_string();
@@ -16,7 +15,7 @@ fn read_file_1() -> Result<String, Error> {
 /// Read address.txt from disk
 #[context]
 fn read_file_2() -> Result<String, Error> {
-    Ok(std::fs::read_to_string("address.txt")?.trim().to_string())
+    Ok(fs::read_to_string("address.txt")?.trim().to_string())
 }
 
 fn main() -> Result<(), Error> {

--- a/examples/square.rs
+++ b/examples/square.rs
@@ -1,5 +1,5 @@
 use context_attribute::context;
-use failure::{ensure, ResultExt};
+use failure::ensure;
 
 /// Square a number if it's less than 10.
 #[context]

--- a/examples/square.rs
+++ b/examples/square.rs
@@ -1,5 +1,5 @@
 use context_attribute::context;
-use failure::ensure;
+use failure::{ensure, ResultExt};
 
 /// Square a number if it's less than 10.
 #[context]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@
 //!
 //! ## Examples
 //!
-//! ```rust
+//! ```no_run
 //! use context_attribute::context;
 //! use failure::{ensure, ResultExt};
 //!
@@ -53,7 +53,7 @@ use syn::{spanned::Spanned, ReturnType};
 ///
 /// # Examples
 ///
-/// ```
+/// ```should_panic
 /// use context_attribute::context;
 /// use failure::{ensure, ResultExt};
 ///
@@ -61,13 +61,15 @@ use syn::{spanned::Spanned, ReturnType};
 ///     let _ = square(2)?;
 ///     let _ = square(5)?;
 ///     let _ = square(11)?;
+///
+///     Ok(())
 /// }
 ///
 /// /// Square a number if it's less than 10.
 /// #[context]
-/// fn square(num: usize) -> Result<String, >{
+/// fn square(num: usize) -> Result<usize, failure::Error>{
 ///     ensure!(num < 10, "Number was larger than 10");
-///     num * num
+///     Ok(num * num)
 /// }
 /// ```
 #[proc_macro_attribute]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,10 +112,7 @@ pub fn context(_attr: TokenStream, item: TokenStream) -> TokenStream {
                 #(#body)*
             };
 
-            Ok(::failure::ResultExt::context(
-                result,
-                #doc.trim()
-            )?)
+            Ok(result.context(#doc.trim())?)
         }
     };
 


### PR DESCRIPTION
Closes #2.

I couldn't figure out a way to get `self` functions to work with the approach currently being used in the library (re-declaring a function in a local scope to shadow the outer decl), so I switched to splicing the body of the function into a block instead - I'm not sure if that breaks anything.

Updated proc macro deps.
Explicitly references `::failure::ResultExt` instead of relying on the user having it in scope.
Usage of the library remains the same, so it shouldn't be a breaking change.

# Known issues (help appreciated)

- I have a check to ensure that the user provides a return type in the function declaration, but currently if a user doesn't supply a type the macro fails at parse time instead of triggering the check.